### PR TITLE
Remove unneeded `K0sControlPlane.Status.ControlPlaneReady` field

### DIFF
--- a/api/controlplane/v1beta1/k0s_types.go
+++ b/api/controlplane/v1beta1/k0s_types.go
@@ -128,7 +128,6 @@ type K0sControlPlaneList struct {
 type K0sControlPlaneStatus struct {
 	// Ready denotes that the control plane is ready
 	Ready                       bool   `json:"ready"`
-	ControlPlaneReady           bool   `json:"controlPlaneReady"`
 	Inititalized                bool   `json:"initialized"`
 	ExternalManagedControlPlane bool   `json:"externalManagedControlPlane"`
 	Replicas                    int32  `json:"replicas"`

--- a/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -370,8 +370,6 @@ spec:
                   - type
                   type: object
                 type: array
-              controlPlaneReady:
-                type: boolean
               externalManagedControlPlane:
                 type: boolean
               initialized:
@@ -396,7 +394,6 @@ spec:
               version:
                 type: string
             required:
-            - controlPlaneReady
             - externalManagedControlPlane
             - initialized
             - ready

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -370,8 +370,6 @@ spec:
                   - type
                   type: object
                 type: array
-              controlPlaneReady:
-                type: boolean
               externalManagedControlPlane:
                 type: boolean
               initialized:
@@ -396,7 +394,6 @@ spec:
               version:
                 type: string
             required:
-            - controlPlaneReady
             - externalManagedControlPlane
             - initialized
             - ready

--- a/docs/resource-reference.md
+++ b/docs/resource-reference.md
@@ -1947,13 +1947,6 @@ More info: http://kubernetes.io/docs/user-guide/labels<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>controlPlaneReady</b></td>
-        <td>boolean</td>
-        <td>
-          <br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>externalManagedControlPlane</b></td>
         <td>boolean</td>
         <td>

--- a/internal/controller/controlplane/k0s_controlplane_controller.go
+++ b/internal/controller/controlplane/k0s_controlplane_controller.go
@@ -163,7 +163,7 @@ func (c *K0sController) Reconcile(ctx context.Context, req ctrl.Request) (res ct
 		}
 		log.Info("Status updated successfully")
 
-		if kcp.Status.ControlPlaneReady {
+		if kcp.Status.Ready {
 			if perr := c.Client.Patch(ctx, cluster, client.Merge); perr != nil {
 				err = fmt.Errorf("failed to patch cluster: %w", perr)
 			}

--- a/internal/controller/controlplane/status.go
+++ b/internal/controller/controlplane/status.go
@@ -188,7 +188,6 @@ func (c *K0sController) updateStatus(ctx context.Context, kcp *cpv1beta1.K0sCont
 	// Set the conditions
 	conditions.MarkTrue(kcp, cpv1beta1.ControlPlaneReadyCondition)
 	kcp.Status.Ready = true
-	kcp.Status.ControlPlaneReady = true
 	kcp.Status.Inititalized = true
 
 	// Set the k0s cluster ID annotation


### PR DESCRIPTION
Im not totally sure about this deletion but I think we can rely on `status.Ready` field. I don't see it as part of CAPI's contract either.