### PR TITLE
Fix conflicts updating resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ $(CONTROLLER_GEN): Makefile.variables | $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.18
 
 .PHONY: docs
 docs:

--- a/api/controlplane/v1beta1/k0s_types.go
+++ b/api/controlplane/v1beta1/k0s_types.go
@@ -127,15 +127,55 @@ type K0sControlPlaneList struct {
 
 type K0sControlPlaneStatus struct {
 	// Ready denotes that the control plane is ready
-	Ready                       bool   `json:"ready"`
-	Inititalized                bool   `json:"initialized"`
-	ExternalManagedControlPlane bool   `json:"externalManagedControlPlane"`
-	Replicas                    int32  `json:"replicas"`
-	Version                     string `json:"version"`
-	Selector                    string `json:"selector"`
-	UnavailableReplicas         int32  `json:"unavailableReplicas"`
-	ReadyReplicas               int32  `json:"readyReplicas"`
-	UpdatedReplicas             int32  `json:"updatedReplicas"`
+	// +optional
+	Ready bool `json:"ready"`
+
+	// initialized denotes that the KubeadmControlPlane API Server is initialized and thus
+	// it can accept requests.
+	// NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+	// The value of this field is never updated after provisioning is completed. Please use conditions
+	// to check the operational state of the control plane.
+	// +optional
+	Inititalized bool `json:"initialized"`
+
+	// externalManagedControlPlane is a bool that should be set to true if the Node objects do not exist in the cluster.
+	// +optional
+	ExternalManagedControlPlane bool `json:"externalManagedControlPlane"`
+
+	// replicas is the total number of non-terminated machines targeted by this control plane
+	// (their labels match the selector).
+	// +optional
+	Replicas int32 `json:"replicas"`
+
+	// version represents the minimum Kubernetes version for the control plane machines
+	// in the cluster.
+	// +optional
+	Version string `json:"version"`
+
+	// selector is the label selector in string format to avoid introspection
+	// by clients, and is used to provide the CRD-based integration for the
+	// scale subresource and additional integrations for things like kubectl
+	// describe.. The string will be in the same format as the query-param syntax.
+	// More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+	// +optional
+	Selector string `json:"selector"`
+
+	// unavailableReplicas is the total number of unavailable machines targeted by this control plane.
+	// This is the total number of machines that are still required for
+	// the deployment to have 100% available capacity. They may either
+	// be machines that are running but not yet ready or machines
+	// that still have not been created.
+	// +optional
+	UnavailableReplicas int32 `json:"unavailableReplicas"`
+
+	// readyReplicas is the total number of fully running and ready control plane machines.
+	// +optional
+	ReadyReplicas int32 `json:"readyReplicas"`
+
+	// updatedReplicas is the total number of non-terminated machines targeted by this control plane
+	// that have the desired template spec.
+	// +optional
+	UpdatedReplicas int32 `json:"updatedReplicas"`
 
 	// Conditions defines current service state of the K0sControlPlane.
 	// +optional

--- a/api/controlplane/v1beta1/k0smotron_types.go
+++ b/api/controlplane/v1beta1/k0smotron_types.go
@@ -60,9 +60,17 @@ type K0smotronControlPlaneList struct {
 
 type K0smotronControlPlaneStatus struct {
 	// Ready denotes that the control plane is ready
-	Ready                       bool `json:"ready"`
-	ControlPlaneReady           bool `json:"controlPlaneReady"`
-	Inititalized                bool `json:"initialized"`
+	// +optional
+	Ready bool `json:"ready"`
+	// initialized denotes that the KubeadmControlPlane API Server is initialized and thus
+	// it can accept requests.
+	// NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+	// The value of this field is never updated after provisioning is completed. Please use conditions
+	// to check the operational state of the control plane.
+	// +optional
+	Inititalized bool `json:"initialized"`
+	// externalManagedControlPlane is a bool that should be set to true if the Node objects do not exist in the cluster.
+	// +optional
 	ExternalManagedControlPlane bool `json:"externalManagedControlPlane"`
 	// version represents the minimum Kubernetes version for the control plane pods
 	// in the cluster.

--- a/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -371,38 +371,59 @@ spec:
                   type: object
                 type: array
               externalManagedControlPlane:
+                description: externalManagedControlPlane is a bool that should be
+                  set to true if the Node objects do not exist in the cluster.
                 type: boolean
               initialized:
+                description: |-
+                  initialized denotes that the KubeadmControlPlane API Server is initialized and thus
+                  it can accept requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
                 type: boolean
               ready:
                 description: Ready denotes that the control plane is ready
                 type: boolean
               readyReplicas:
+                description: readyReplicas is the total number of fully running and
+                  ready control plane machines.
                 format: int32
                 type: integer
               replicas:
+                description: |-
+                  replicas is the total number of non-terminated machines targeted by this control plane
+                  (their labels match the selector).
                 format: int32
                 type: integer
               selector:
+                description: |-
+                  selector is the label selector in string format to avoid introspection
+                  by clients, and is used to provide the CRD-based integration for the
+                  scale subresource and additional integrations for things like kubectl
+                  describe.. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
                 type: string
               unavailableReplicas:
+                description: |-
+                  unavailableReplicas is the total number of unavailable machines targeted by this control plane.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet ready or machines
+                  that still have not been created.
                 format: int32
                 type: integer
               updatedReplicas:
+                description: |-
+                  updatedReplicas is the total number of non-terminated machines targeted by this control plane
+                  that have the desired template spec.
                 format: int32
                 type: integer
               version:
+                description: |-
+                  version represents the minimum Kubernetes version for the control plane machines
+                  in the cluster.
                 type: string
-            required:
-            - externalManagedControlPlane
-            - initialized
-            - ready
-            - readyReplicas
-            - replicas
-            - selector
-            - unavailableReplicas
-            - updatedReplicas
-            - version
             type: object
         type: object
     served: true

--- a/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
+++ b/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
@@ -4528,11 +4528,17 @@ spec:
             type: object
           status:
             properties:
-              controlPlaneReady:
-                type: boolean
               externalManagedControlPlane:
+                description: externalManagedControlPlane is a bool that should be
+                  set to true if the Node objects do not exist in the cluster.
                 type: boolean
               initialized:
+                description: |-
+                  initialized denotes that the KubeadmControlPlane API Server is initialized and thus
+                  it can accept requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
                 type: boolean
               ready:
                 description: Ready denotes that the control plane is ready
@@ -4565,11 +4571,6 @@ spec:
                   version represents the minimum Kubernetes version for the control plane pods
                   in the cluster.
                 type: string
-            required:
-            - controlPlaneReady
-            - externalManagedControlPlane
-            - initialized
-            - ready
             type: object
         type: object
     served: true

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -371,38 +371,59 @@ spec:
                   type: object
                 type: array
               externalManagedControlPlane:
+                description: externalManagedControlPlane is a bool that should be
+                  set to true if the Node objects do not exist in the cluster.
                 type: boolean
               initialized:
+                description: |-
+                  initialized denotes that the KubeadmControlPlane API Server is initialized and thus
+                  it can accept requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
                 type: boolean
               ready:
                 description: Ready denotes that the control plane is ready
                 type: boolean
               readyReplicas:
+                description: readyReplicas is the total number of fully running and
+                  ready control plane machines.
                 format: int32
                 type: integer
               replicas:
+                description: |-
+                  replicas is the total number of non-terminated machines targeted by this control plane
+                  (their labels match the selector).
                 format: int32
                 type: integer
               selector:
+                description: |-
+                  selector is the label selector in string format to avoid introspection
+                  by clients, and is used to provide the CRD-based integration for the
+                  scale subresource and additional integrations for things like kubectl
+                  describe.. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
                 type: string
               unavailableReplicas:
+                description: |-
+                  unavailableReplicas is the total number of unavailable machines targeted by this control plane.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet ready or machines
+                  that still have not been created.
                 format: int32
                 type: integer
               updatedReplicas:
+                description: |-
+                  updatedReplicas is the total number of non-terminated machines targeted by this control plane
+                  that have the desired template spec.
                 format: int32
                 type: integer
               version:
+                description: |-
+                  version represents the minimum Kubernetes version for the control plane machines
+                  in the cluster.
                 type: string
-            required:
-            - externalManagedControlPlane
-            - initialized
-            - ready
-            - readyReplicas
-            - replicas
-            - selector
-            - unavailableReplicas
-            - updatedReplicas
-            - version
             type: object
         type: object
     served: true

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
@@ -4528,11 +4528,17 @@ spec:
             type: object
           status:
             properties:
-              controlPlaneReady:
-                type: boolean
               externalManagedControlPlane:
+                description: externalManagedControlPlane is a bool that should be
+                  set to true if the Node objects do not exist in the cluster.
                 type: boolean
               initialized:
+                description: |-
+                  initialized denotes that the KubeadmControlPlane API Server is initialized and thus
+                  it can accept requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
                 type: boolean
               ready:
                 description: Ready denotes that the control plane is ready
@@ -4565,11 +4571,6 @@ spec:
                   version represents the minimum Kubernetes version for the control plane pods
                   in the cluster.
                 type: string
-            required:
-            - controlPlaneReady
-            - externalManagedControlPlane
-            - initialized
-            - ready
             type: object
         type: object
     served: true

--- a/docs/resource-reference.md
+++ b/docs/resource-reference.md
@@ -1947,81 +1947,96 @@ More info: http://kubernetes.io/docs/user-guide/labels<br/>
         </tr>
     </thead>
     <tbody><tr>
+        <td><b><a href="#k0scontrolplanestatusconditionsindex">conditions</a></b></td>
+        <td>[]object</td>
+        <td>
+          Conditions defines current service state of the K0sControlPlane.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>externalManagedControlPlane</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          externalManagedControlPlane is a bool that should be set to true if the Node objects do not exist in the cluster.<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b>initialized</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          initialized denotes that the KubeadmControlPlane API Server is initialized and thus
+it can accept requests.
+NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+The value of this field is never updated after provisioning is completed. Please use conditions
+to check the operational state of the control plane.<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b>ready</b></td>
         <td>boolean</td>
         <td>
           Ready denotes that the control plane is ready<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b>readyReplicas</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          readyReplicas is the total number of fully running and ready control plane machines.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b>replicas</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          replicas is the total number of non-terminated machines targeted by this control plane
+(their labels match the selector).<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b>selector</b></td>
         <td>string</td>
         <td>
-          <br/>
+          selector is the label selector in string format to avoid introspection
+by clients, and is used to provide the CRD-based integration for the
+scale subresource and additional integrations for things like kubectl
+describe.. The string will be in the same format as the query-param syntax.
+More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b>unavailableReplicas</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          unavailableReplicas is the total number of unavailable machines targeted by this control plane.
+This is the total number of machines that are still required for
+the deployment to have 100% available capacity. They may either
+be machines that are running but not yet ready or machines
+that still have not been created.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b>updatedReplicas</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          updatedReplicas is the total number of non-terminated machines targeted by this control plane
+that have the desired template spec.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b>version</b></td>
         <td>string</td>
         <td>
-          <br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b><a href="#k0scontrolplanestatusconditionsindex">conditions</a></b></td>
-        <td>[]object</td>
-        <td>
-          Conditions defines current service state of the K0sControlPlane.<br/>
+          version represents the minimum Kubernetes version for the control plane machines
+in the cluster.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11774,33 +11789,30 @@ merge patch.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>controlPlaneReady</b></td>
-        <td>boolean</td>
-        <td>
-          <br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>externalManagedControlPlane</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          externalManagedControlPlane is a bool that should be set to true if the Node objects do not exist in the cluster.<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b>initialized</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          initialized denotes that the KubeadmControlPlane API Server is initialized and thus
+it can accept requests.
+NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+The value of this field is never updated after provisioning is completed. Please use conditions
+to check the operational state of the control plane.<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b>ready</b></td>
         <td>boolean</td>
         <td>
           Ready denotes that the control plane is ready<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b>readyReplicas</b></td>
         <td>integer</td>

--- a/internal/controller/controlplane/k0s_controlplane_controller_test.go
+++ b/internal/controller/controlplane/k0s_controlplane_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -815,7 +816,7 @@ func TestReconcileK0sConfigWithNLLBEnabled(t *testing.T) {
 			},
 		},
 	}
-	require.Equal(t, expectedk0sConfig, kcp.Spec.K0sConfigSpec.K0s)
+	require.Equal(t, normalizeUnstructured(expectedk0sConfig), normalizeUnstructured(kcp.Spec.K0sConfigSpec.K0s))
 }
 
 func TestReconcileK0sConfigWithNLLBDisabled(t *testing.T) {
@@ -868,7 +869,7 @@ func TestReconcileK0sConfigWithNLLBDisabled(t *testing.T) {
 			},
 		},
 	}
-	require.Equal(t, expectedk0sConfig, kcp.Spec.K0sConfigSpec.K0s)
+	require.Equal(t, normalizeUnstructured(expectedk0sConfig), normalizeUnstructured(kcp.Spec.K0sConfigSpec.K0s))
 }
 
 func TestReconcileK0sConfigTunnelingServerAddressToApiSans(t *testing.T) {
@@ -925,7 +926,7 @@ func TestReconcileK0sConfigTunnelingServerAddressToApiSans(t *testing.T) {
 			},
 		},
 	}
-	require.Equal(t, expectedk0sConfig, kcp.Spec.K0sConfigSpec.K0s)
+	require.Equal(t, normalizeUnstructured(expectedk0sConfig), normalizeUnstructured(kcp.Spec.K0sConfigSpec.K0s))
 }
 
 func TestReconcileMachinesScaleUp(t *testing.T) {
@@ -1481,7 +1482,7 @@ func TestReconcileInitializeControlPlanes(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, testEnv.GetAPIReader().Get(ctx, client.ObjectKey{Name: kcp.Name, Namespace: kcp.Namespace}, kcp))
 	require.NotEmpty(t, kcp.Status.Selector)
-	require.Equal(t, fmt.Sprintf("%s+%s", kcp.Spec.Version, defaultK0sSuffix), kcp.Status.Version)
+	require.Equal(t, "v1.30.0+k0s.0", kcp.Status.Version)
 	require.Equal(t, kcp.Status.Replicas, int32(1))
 	require.NoError(t, testEnv.GetAPIReader().Get(ctx, util.ObjectKey(gmt), gmt))
 	require.Contains(t, gmt.GetOwnerReferences(), metav1.OwnerReference{
@@ -1533,7 +1534,7 @@ func TestReconcileInitializeControlPlanes(t *testing.T) {
 	require.Len(t, machineList.Items, 1)
 	machine := machineList.Items[0]
 	require.True(t, strings.HasPrefix(machine.Name, kcp.Name))
-	require.Equal(t, fmt.Sprintf("%s+%s", kcp.Spec.Version, defaultK0sSuffix), *machine.Spec.Version)
+	require.Equal(t, "v1.30.0+k0s.0", *machine.Spec.Version)
 	// Newly cloned infra objects should have the infraref annotation.
 	infraObj, err := external.Get(ctx, r.Client, &machine.Spec.InfrastructureRef, machine.Spec.InfrastructureRef.Namespace)
 	require.NoError(t, err)
@@ -1766,4 +1767,28 @@ func createClusterWithControlPlane(namespace string) (*clusterv1.Cluster, *cpv1b
 		},
 	}
 	return cluster, kcp, genericMachineTemplate
+}
+
+// normalizeUnstructured normalizes an unstructured object by sorting the "sans" field
+func normalizeUnstructured(obj *unstructured.Unstructured) *unstructured.Unstructured {
+	normalized := obj.DeepCopy()
+
+	sans, found, err := unstructured.NestedSlice(normalized.Object, "spec", "api", "sans")
+	if err == nil && found {
+		strSans := make([]string, len(sans))
+		for i, v := range sans {
+			strSans[i] = v.(string)
+		}
+
+		sort.Strings(strSans)
+
+		sortedSans := make([]interface{}, len(strSans))
+		for i, v := range strSans {
+			sortedSans[i] = v
+		}
+
+		_ = unstructured.SetNestedSlice(normalized.Object, sortedSans, "spec", "api", "sans")
+	}
+
+	return normalized
 }

--- a/internal/controller/k0smotron.io/k0smotroncluster_entrypoint.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_entrypoint.go
@@ -68,11 +68,11 @@ func (r *ClusterReconciler) generateEntrypointCM(kmc *km.Cluster) (v1.ConfigMap,
 	return cm, nil
 }
 
-func (r *ClusterReconciler) reconcileEntrypointCM(ctx context.Context, kmc km.Cluster) error {
+func (r *ClusterReconciler) reconcileEntrypointCM(ctx context.Context, kmc *km.Cluster) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Reconciling entrypoint configmap")
 
-	cm, err := r.generateEntrypointCM(&kmc)
+	cm, err := r.generateEntrypointCM(kmc)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/k0smotron.io/k0smotroncluster_kubeconfig.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_kubeconfig.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func (r *ClusterReconciler) reconcileKubeConfigSecret(ctx context.Context, kmc km.Cluster) error {
+func (r *ClusterReconciler) reconcileKubeConfigSecret(ctx context.Context, kmc *km.Cluster) error {
 	logger := log.FromContext(ctx)
 	pod, err := r.findStatefulSetPod(ctx, kmc.GetStatefulSetName(), kmc.Namespace)
 
@@ -54,14 +54,14 @@ func (r *ClusterReconciler) reconcileKubeConfigSecret(ctx context.Context, kmc k
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        kmc.GetAdminConfigSecretName(),
 			Namespace:   kmc.Namespace,
-			Labels:      kcontrollerutil.LabelsForK0smotronCluster(&kmc),
-			Annotations: kcontrollerutil.AnnotationsForK0smotronCluster(&kmc),
+			Labels:      kcontrollerutil.LabelsForK0smotronCluster(kmc),
+			Annotations: kcontrollerutil.AnnotationsForK0smotronCluster(kmc),
 		},
 		StringData: map[string]string{"value": output},
 		Type:       clusterv1.ClusterSecretType,
 	}
 
-	if err = ctrl.SetControllerReference(&kmc, &secret, r.Scheme); err != nil {
+	if err = ctrl.SetControllerReference(kmc, &secret, r.Scheme); err != nil {
 		return err
 	}
 

--- a/internal/controller/k0smotron.io/k0smotroncluster_monitoring_config.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_monitoring_config.go
@@ -70,11 +70,11 @@ func (r *ClusterReconciler) generateMonitoringCM(kmc *km.Cluster) (v1.ConfigMap,
 	return cm, nil
 }
 
-func (r *ClusterReconciler) reconcileMonitoringCM(ctx context.Context, kmc km.Cluster) error {
+func (r *ClusterReconciler) reconcileMonitoringCM(ctx context.Context, kmc *km.Cluster) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Reconciling monitoring configmap")
 
-	cm, err := r.generateMonitoringCM(&kmc)
+	cm, err := r.generateMonitoringCM(kmc)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/k0smotron.io/k0smotroncluster_service.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_service.go
@@ -131,13 +131,13 @@ func (r *ClusterReconciler) generateService(kmc *km.Cluster) v1.Service {
 	return svc
 }
 
-func (r *ClusterReconciler) reconcileServices(ctx context.Context, kmc km.Cluster) error {
+func (r *ClusterReconciler) reconcileServices(ctx context.Context, kmc *km.Cluster) error {
 	logger := log.FromContext(ctx)
 	// Depending on ingress configuration create nodePort service.
 	logger.Info("Reconciling services")
-	svc := r.generateService(&kmc)
+	svc := r.generateService(kmc)
 
-	_ = ctrl.SetControllerReference(&kmc, &svc, r.Scheme)
+	_ = ctrl.SetControllerReference(kmc, &svc, r.Scheme)
 
 	if err := r.Client.Patch(ctx, &svc, client.Apply, patchOpts...); err != nil {
 		return err
@@ -159,7 +159,7 @@ func (r *ClusterReconciler) reconcileServices(ctx context.Context, kmc km.Cluste
 				}
 				logger.Info("Loadbalancer address available, updating Cluster object", "address", kmc.Spec.ExternalAddress)
 
-				err := r.Client.Update(ctx, &kmc)
+				err := r.Client.Update(ctx, kmc)
 				if err != nil {
 					return false, err
 				}
@@ -178,9 +178,6 @@ func (r *ClusterReconciler) reconcileServices(ctx context.Context, kmc km.Cluste
 			return err
 		}
 		kmc.Spec.ExternalAddress = util.FindNodeAddress(nodes)
-		if err := r.Client.Update(ctx, &kmc); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
@@ -531,10 +531,10 @@ func (r *ClusterReconciler) addMonitoringStack(kmc *km.Cluster, statefulSet *app
 	})
 }
 
-func (r *ClusterReconciler) reconcileStatefulSet(ctx context.Context, kmc km.Cluster) error {
+func (r *ClusterReconciler) reconcileStatefulSet(ctx context.Context, kmc *km.Cluster) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Reconciling statefulset")
-	statefulSet, err := r.generateStatefulSet(&kmc)
+	statefulSet, err := r.generateStatefulSet(kmc)
 	if err != nil {
 		return fmt.Errorf("failed to generate statefulset: %w", err)
 	}
@@ -548,7 +548,7 @@ func (r *ClusterReconciler) reconcileStatefulSet(ctx context.Context, kmc km.Clu
 		}
 
 		if foundStatefulSet.Status.ReadyReplicas == kmc.Spec.Replicas {
-			r.updateReadiness(ctx, kmc, true)
+			kmc.Status.Ready = true
 		}
 
 		return nil

--- a/internal/controller/util/util.go
+++ b/internal/controller/util/util.go
@@ -33,3 +33,20 @@ func LabelsForEtcdK0smotronCluster(kmc *km.Cluster) map[string]string {
 func AnnotationsForK0smotronCluster(kmc *km.Cluster) map[string]string {
 	return kmc.Annotations
 }
+
+// AddToExistingSans merges original sans list with a new sans slice avoiding duplicated values.
+func AddToExistingSans(existing []string, new []string) []string {
+	uniques := make(map[string]struct{})
+	for _, val := range existing {
+		uniques[val] = struct{}{}
+	}
+	for _, val := range new {
+		uniques[val] = struct{}{}
+	}
+	finalSans := make([]string, 0, len(uniques))
+	for key := range uniques {
+		finalSans = append(finalSans, key)
+	}
+
+	return finalSans
+}


### PR DESCRIPTION
fix #937 

Change patch followed strategy to using https://pkg.go.dev/sigs.k8s.io/cluster-api@v1.8.5/util/patch. This packages uses `client.MergeFrom` option to patch the resource using the diff between updated one and the original. This way we prevent conflicts if other controller are updating the resource concurrently. By adopting this new patch strategy, some bugs have appeared when updating resources. For example, not taking into account the previous status when filing the resource. This was not a problem because only the subresource `.status` was updated but at runtime the resource could have duplicate values (see diff comments).

New approach it is only change in those resources which can potentially face a conflict when they are updated by k0smotron and CAPI.