### PR TITLE
Fix command formatting for sudo execution in SSH commands

### DIFF
--- a/internal/controller/infrastructure/job_provisioner.go
+++ b/internal/controller/infrastructure/job_provisioner.go
@@ -169,9 +169,9 @@ func (p *JobProvisioner) extractCloudInit(cloudInit *cloudinit.CloudInit) (volum
 
 	for _, cmd := range cloudInit.RunCmds {
 		if p.remoteMachine.Spec.UseSudo {
-			cmd = fmt.Sprintf("sudo su -c \\'%s\\'\n", cmd)
+			cmd = fmt.Sprintf("sudo su -c '%s'", cmd)
 		}
-		buf.WriteString(fmt.Sprintf("%s '%s'\n", sshCommand, cmd))
+		buf.WriteString(fmt.Sprintf("%s \"%s\"\n", sshCommand, cmd))
 	}
 	secretData["k0smotron-entrypoint.sh"] = buf.Bytes()
 

--- a/inttest/capi-remote-machine-job-provision/capi_remote_machine_job_provision_test.go
+++ b/inttest/capi-remote-machine-job-provision/capi_remote_machine_job_provision_test.go
@@ -24,12 +24,13 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	infra "github.com/k0smotron/k0smotron/api/infrastructure/v1beta1"
-	"github.com/k0smotron/k0smotron/inttest/util"
-	"github.com/k0sproject/k0s/inttest/common"
 	"os"
 	"testing"
 	"text/template"
+
+	infra "github.com/k0smotron/k0smotron/api/infrastructure/v1beta1"
+	"github.com/k0smotron/k0smotron/inttest/util"
+	"github.com/k0sproject/k0s/inttest/common"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -319,6 +320,7 @@ metadata:
 spec:
   address: {{ .Address }}
   user: root
+  useSudo: true
   provisionJob:
     sshCommand: "ssh -o \"StrictHostKeyChecking=no\""
     scpCommand: "scp -o \"StrictHostKeyChecking=no\""

--- a/inttest/footloose-alpine/Dockerfile
+++ b/inttest/footloose-alpine/Dockerfile
@@ -10,7 +10,7 @@ ARG TROUBLESHOOT_VERSION=v0.61.0
 # Apply our changes to the image
 COPY root/ /
 
-RUN apk add openrc openssh-server bash busybox-openrc coreutils curl inotify-tools
+RUN apk add openrc openssh-server bash busybox-openrc coreutils curl inotify-tools sudo
 # enable syslog and sshd
 RUN rc-update add cgroups boot
 RUN rc-update add syslog boot


### PR DESCRIPTION
Before:
```sh
#!/bin/sh
scp -o "StrictHostKeyChecking=no" -P 22 /var/lib/bootstrap-data/k0s.token-7bb70f1ce2333cb0fd3e9b5fa17efc73 root@172.18.0.3:/etc/k0s.token
ssh -o "StrictHostKeyChecking=no" -p 22 root@172.18.0.3 'sudo su -c \'curl -sSfL https://get.k0s.sh | K0S_VERSION=v1.27.2+k0s.0 sh\'
'
ssh -o "StrictHostKeyChecking=no" -p 22 root@172.18.0.3 'sudo su -c \'k0s install worker --token-file /etc/k0s.token --labels=k0smotron.io/machine-name=remote-test-0 --kubelet-extra-args="--hostname-override=remote-test-0"\'
'
ssh -o "StrictHostKeyChecking=no" -p 22 root@172.18.0.3 'sudo su -c \'(command -v systemctl > /dev/null 2>&1 && systemctl start k0sworker) || (command -v rc-service > /dev/null 2>&1 && rc-service k0sworker start) || (command -v service > /dev/null 2>&1 && service k0sworker start) || (echo "Not a supported init system"; false)\'
'
ssh -o "StrictHostKeyChecking=no" -p 22 root@172.18.0.3 'sudo su -c \'mkdir -p /run/cluster-api && touch /run/cluster-api/bootstrap-success.complete\'
'
```

After:
```sh
#!/bin/sh
scp -o "StrictHostKeyChecking=no" -P 22 /var/lib/bootstrap-data/k0s.token-7bb70f1ce2333cb0fd3e9b5fa17efc73 root@172.18.0.3:/etc/k0s.token
ssh -o "StrictHostKeyChecking=no" -p 22 root@172.18.0.3 "sudo su -c \'curl -sSfL https://get.k0s.sh | K0S_VERSION=v1.27.2+k0s.0 sh\'"
ssh -o "StrictHostKeyChecking=no" -p 22 root@172.18.0.3 "sudo su -c \'k0s install worker --token-file /etc/k0s.token --labels=k0smotron.io/machine-name=remote-test-0 --kubelet-extra-args="--hostname-override=remote-test-0"\'"
ssh -o "StrictHostKeyChecking=no" -p 22 root@172.18.0.3 "sudo su -c \'(command -v systemctl > /dev/null 2>&1 && systemctl start k0sworker) || (command -v rc-service > /dev/null 2>&1 && rc-service k0sworker start) || (command -v service > /dev/null 2>&1 && service k0sworker start) || (echo "Not a supported init system"; false)\'"
ssh -o "StrictHostKeyChecking=no" -p 22 root@172.18.0.3 "sudo su -c \'mkdir -p /run/cluster-api && touch /run/cluster-api/bootstrap-success.complete\'"
```

```cmd
/ # ps aux
PID   USER     TIME  COMMAND
    1 root      0:00 /sbin/init
  222 root      0:00 /sbin/syslogd -t -n
  300 root      0:00 sshd: /usr/sbin/sshd [listener] 0 of 10-100 startups
  338 root      0:00 sshd: root@notty
  513 root      0:00 supervise-daemon k0sworker --start --respawn-delay 2 --respawn-max 5 --respawn-period 1800 --stdout /var/log/k0s.log --stderr /var/log/k0s.err /usr/local/bin/k0s -- worker --kubelet-extra-args=--hostname-override=remote-test-0 --labels=k0smotron.
  514 root      0:00 /usr/local/bin/k0s worker --kubelet-extra-args=--hostname-override=remote-test-0 --labels=k0smotron.io/machine-name=remote-test-0 --token-file=/etc/k0s.token
  538 root      0:03 /var/lib/k0s/bin/containerd --root=/var/lib/k0s/containerd --state=/run/k0s/containerd --address=/run/k0s/containerd.sock --log-level=info --config=/etc/k0s/containerd.toml
  544 root      0:00 /var/lib/k0s/bin/kubelet --runtime-cgroups=/system.slice/containerd.service --root-dir=/var/lib/k0s/kubelet --config=/var/lib/k0s/kubelet-config.yaml --node-labels=k0smotron.io/machine-name=remote-test-0 --kubeconfig=/var/lib/k0s/kubelet.conf --v
  602 root      0:00 /var/lib/k0s/bin/containerd-shim-runc-v2 -namespace k8s.io -id 37654b553605f0b35c6b8a99bb7b110bc5aa499a05224fc65c68e463279efc6a -address /run/k0s/containerd.sock
  617 root      0:00 /var/lib/k0s/bin/containerd-shim-runc-v2 -namespace k8s.io -id 1f3dec1371ff2b768e6f486e6fe7526ec84630da3161cda2c05d339b94c8eced -address /run/k0s/containerd.sock
  643 65535     0:00 /pause
  645 65535     0:00 /pause
  694 root      0:00 /usr/local/bin/kube-proxy --config=/var/lib/kube-proxy/config.conf --hostname-override=remote-test-0
 1070 root      0:00 /usr/local/bin/kube-router --run-router=true --run-firewall=true --run-service-proxy=false --bgp-graceful-restart=true --metrics-port=8080 --hairpin-mode=true
 1342 root      0:00 /var/lib/k0s/bin/containerd-shim-runc-v2 -namespace k8s.io -id a954d1a7a0c505e7c7671c35f91c8efe5a91d6fd23e4d162788022d551dd66ae -address /run/k0s/containerd.sock
 1364 65535     0:00 /pause
 1593 root      0:00 /var/lib/k0s/bin/containerd-shim-runc-v2 -namespace k8s.io -id b912dc4dbd8231400bf02b0a98689fa2a9a38b0b3f8f476b0ddd7b30ef3266d0 -address /run/k0s/containerd.sock
 1614 65535     0:00 /pause
 1657 root      0:00 /var/lib/k0s/bin/containerd-shim-runc-v2 -namespace k8s.io -id ef575f15ed27aedef3c84ccdb759322fbdb36cbcf204c96069167c025b6b2225 -address /run/k0s/containerd.sock
 1677 65535     0:00 /pause
 1707 1000      0:00 /metrics-server --cert-dir=/tmp --secure-port=10250 --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname --kubelet-use-node-status-port --metric-resolution=15s
 1782 root      0:00 /proxy-agent --logtostderr=true --ca-cert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt --proxy-server-host=172.18.0.2 --proxy-server-port=30132 --service-account-token-path=/var/run/secrets/tokens/konnectivity-agent-token --agent-identifi
 1824 root      0:00 sh
 1896 root      0:00 ps aux
/ # exit
```