### PR TITLE
Add controlplane finalizer to ensure machine deletion

### DIFF
--- a/api/controlplane/v1beta1/k0s_types.go
+++ b/api/controlplane/v1beta1/k0s_types.go
@@ -47,6 +47,10 @@ const (
 
 	// ControlPlanePausedCondition documents the reconciliation of the control plane is paused.
 	ControlPlanePausedCondition clusterv1.ConditionType = "Paused"
+
+	// K0sControlPlaneFinalizer is the finalizer applied to KubeadmControlPlane resources
+	// by its managing controller.
+	K0sControlPlaneFinalizer = "k0s.controlplane.cluster.x-k8s.io"
 )
 
 // +kubebuilder:object:root=true

--- a/internal/controller/controlplane/k0s_controlplane_controller_test.go
+++ b/internal/controller/controlplane/k0s_controlplane_controller_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,7 +59,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	bootstrapv1 "github.com/k0smotron/k0smotron/api/bootstrap/v1beta1"
-	"github.com/k0smotron/k0smotron/api/controlplane/v1beta1"
 	cpv1beta1 "github.com/k0smotron/k0smotron/api/controlplane/v1beta1"
 	autopilot "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	kubeadmConfig "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
@@ -69,12 +67,12 @@ import (
 func TestK0sConfigEnrichment(t *testing.T) {
 	var testCases = []struct {
 		cluster *clusterv1.Cluster
-		kcp     *v1beta1.K0sControlPlane
+		kcp     *cpv1beta1.K0sControlPlane
 		want    *unstructured.Unstructured
 	}{
 		{
 			cluster: &clusterv1.Cluster{},
-			kcp:     &v1beta1.K0sControlPlane{},
+			kcp:     &cpv1beta1.K0sControlPlane{},
 			want:    nil,
 		},
 		{
@@ -90,7 +88,7 @@ func TestK0sConfigEnrichment(t *testing.T) {
 					},
 				},
 			},
-			kcp: &v1beta1.K0sControlPlane{},
+			kcp: &cpv1beta1.K0sControlPlane{},
 			want: &unstructured.Unstructured{Object: map[string]interface{}{
 				"apiVersion": "k0s.k0sproject.io/v1beta1",
 				"kind":       "ClusterConfig",
@@ -112,8 +110,8 @@ func TestK0sConfigEnrichment(t *testing.T) {
 					},
 				},
 			},
-			kcp: &v1beta1.K0sControlPlane{
-				Spec: v1beta1.K0sControlPlaneSpec{
+			kcp: &cpv1beta1.K0sControlPlane{
+				Spec: cpv1beta1.K0sControlPlaneSpec{
 					K0sConfigSpec: bootstrapv1.K0sConfigSpec{
 						K0s: &unstructured.Unstructured{Object: map[string]interface{}{
 							"spec": map[string]interface{}{
@@ -139,7 +137,7 @@ func TestK0sConfigEnrichment(t *testing.T) {
 					},
 				},
 			},
-			kcp: &v1beta1.K0sControlPlane{},
+			kcp: &cpv1beta1.K0sControlPlane{},
 			want: &unstructured.Unstructured{Object: map[string]interface{}{
 				"apiVersion": "k0s.k0sproject.io/v1beta1",
 				"kind":       "ClusterConfig",
@@ -236,11 +234,11 @@ func Test_machineName(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		kcp := &v1beta1.K0sControlPlane{
+		kcp := &cpv1beta1.K0sControlPlane{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
 			},
-			Spec: v1beta1.K0sControlPlaneSpec{
+			Spec: cpv1beta1.K0sControlPlaneSpec{
 				Replicas: tc.replicas,
 			},
 		}
@@ -980,7 +978,7 @@ func TestReconcileMachinesScaleUp(t *testing.T) {
 		Spec: clusterv1.MachineSpec{
 			ClusterName: cluster.Name,
 			Version:     ptr.To("v1.30.0"),
-			InfrastructureRef: v1.ObjectReference{
+			InfrastructureRef: corev1.ObjectReference{
 				Kind:       "GenericInfrastructureMachineTemplate",
 				Namespace:  ns.Name,
 				Name:       gmt.GetName(),
@@ -1004,7 +1002,7 @@ func TestReconcileMachinesScaleUp(t *testing.T) {
 		Spec: clusterv1.MachineSpec{
 			ClusterName: cluster.Name,
 			Version:     ptr.To("v1.30.0"),
-			InfrastructureRef: v1.ObjectReference{
+			InfrastructureRef: corev1.ObjectReference{
 				Kind:       "GenericInfrastructureMachineTemplate",
 				Namespace:  ns.Name,
 				Name:       gmt.GetName(),
@@ -1116,7 +1114,7 @@ func TestReconcileMachinesScaleDown(t *testing.T) {
 		Spec: clusterv1.MachineSpec{
 			ClusterName: cluster.Name,
 			Version:     ptr.To("v1.30.0"),
-			InfrastructureRef: v1.ObjectReference{
+			InfrastructureRef: corev1.ObjectReference{
 				Kind:       "GenericInfrastructureMachineTemplate",
 				Namespace:  ns.Name,
 				Name:       gmt.GetName(),
@@ -1156,7 +1154,7 @@ func TestReconcileMachinesScaleDown(t *testing.T) {
 		Spec: clusterv1.MachineSpec{
 			ClusterName: cluster.Name,
 			Version:     ptr.To("v1.30.0"),
-			InfrastructureRef: v1.ObjectReference{
+			InfrastructureRef: corev1.ObjectReference{
 				Kind:       "GenericInfrastructureMachineTemplate",
 				Namespace:  ns.Name,
 				Name:       gmt.GetName(),
@@ -1196,7 +1194,7 @@ func TestReconcileMachinesScaleDown(t *testing.T) {
 		Spec: clusterv1.MachineSpec{
 			ClusterName: cluster.Name,
 			Version:     ptr.To("v1.30.0"),
-			InfrastructureRef: v1.ObjectReference{
+			InfrastructureRef: corev1.ObjectReference{
 				Kind:       "GenericInfrastructureMachineTemplate",
 				Namespace:  ns.Name,
 				Name:       gmt.GetName(),
@@ -1341,7 +1339,7 @@ func TestReconcileMachinesSyncOldMachines(t *testing.T) {
 		Spec: clusterv1.MachineSpec{
 			ClusterName: cluster.Name,
 			Version:     ptr.To("v1.29.0"),
-			InfrastructureRef: v1.ObjectReference{
+			InfrastructureRef: corev1.ObjectReference{
 				Kind:       "GenericInfrastructureMachineTemplate",
 				Namespace:  ns.Name,
 				Name:       gmt.GetName(),
@@ -1380,7 +1378,7 @@ func TestReconcileMachinesSyncOldMachines(t *testing.T) {
 		Spec: clusterv1.MachineSpec{
 			ClusterName: cluster.Name,
 			Version:     ptr.To("v1.30.0"),
-			InfrastructureRef: v1.ObjectReference{
+			InfrastructureRef: corev1.ObjectReference{
 				Kind:       "GenericInfrastructureMachineTemplate",
 				Namespace:  ns.Name,
 				Name:       gmt.GetName(),
@@ -1418,7 +1416,7 @@ func TestReconcileMachinesSyncOldMachines(t *testing.T) {
 		Spec: clusterv1.MachineSpec{
 			ClusterName: cluster.Name,
 			Version:     ptr.To("v1.29.0"),
-			InfrastructureRef: v1.ObjectReference{
+			InfrastructureRef: corev1.ObjectReference{
 				Kind:       "GenericInfrastructureMachineTemplate",
 				Namespace:  ns.Name,
 				Name:       gmt.GetName(),
@@ -1476,6 +1474,93 @@ func TestReconcileMachinesSyncOldMachines(t *testing.T) {
 			assert.True(c, metav1.IsControlledBy(kc, m))
 		}
 	}, 5*time.Second, 100*time.Millisecond)
+}
+
+func TestReconcileDeleteControlPlanes(t *testing.T) {
+	ns, err := testEnv.CreateNamespace(ctx, "test-reconcile-delete-controlplane")
+	require.NoError(t, err)
+
+	cluster, kcp, gmt := createClusterWithControlPlane(ns.Name)
+	require.NoError(t, testEnv.Create(ctx, cluster))
+	require.NoError(t, testEnv.Create(ctx, kcp))
+	require.NoError(t, testEnv.Create(ctx, gmt))
+	defer func(do ...client.Object) {
+		require.NoError(t, testEnv.Cleanup(ctx, do...))
+	}(kcp, cluster, gmt, ns)
+
+	r := &K0sController{
+		Client: testEnv,
+	}
+
+	// All control plane machines are already deleted.
+	res, err := r.reconcileDelete(ctx, cluster, kcp)
+	require.NoError(t, err)
+	require.True(t, res.IsZero())
+
+	clusterOwnerRef := *metav1.NewControllerRef(kcp, clusterv1.GroupVersion.WithKind("Cluster"))
+
+	workerMachine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%d", kcp.Name, 0),
+			Namespace: ns.Name,
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel: cluster.Name,
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: cluster.Name,
+			Version:     ptr.To("v1.30.0"),
+			InfrastructureRef: corev1.ObjectReference{
+				Kind:       "GenericInfrastructureMachineTemplate",
+				Namespace:  ns.Name,
+				Name:       gmt.GetName(),
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			},
+		},
+	}
+	workerMachine.SetOwnerReferences([]metav1.OwnerReference{clusterOwnerRef})
+	require.NoError(t, testEnv.Create(ctx, workerMachine))
+
+	controlplaneMachine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%d", kcp.Name, 1),
+			Namespace: ns.Name,
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel:             cluster.Name,
+				clusterv1.MachineControlPlaneLabel:     "true",
+				clusterv1.MachineControlPlaneNameLabel: kcp.GetName(),
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: cluster.Name,
+			Version:     ptr.To("v1.30.0"),
+			InfrastructureRef: corev1.ObjectReference{
+				Kind:       "GenericInfrastructureMachineTemplate",
+				Namespace:  ns.Name,
+				Name:       gmt.GetName(),
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			},
+		},
+	}
+	controlplaneMachine.SetOwnerReferences([]metav1.OwnerReference{clusterOwnerRef})
+	require.NoError(t, testEnv.Create(ctx, controlplaneMachine))
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		// Worker machines needs to be deleted first.
+		res, err = r.reconcileDelete(ctx, cluster, kcp)
+		assert.NoError(c, err)
+		assert.False(c, res.IsZero())
+	}, 10*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, testEnv.Delete(ctx, workerMachine))
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		// Control plane machine can be deleted.
+		res, err = r.reconcileDelete(ctx, cluster, kcp)
+		assert.NoError(c, err)
+		assert.False(c, res.IsZero())
+	}, 10*time.Second, 100*time.Millisecond)
+
 }
 
 func TestReconcileInitializeControlPlanes(t *testing.T) {
@@ -1713,16 +1798,16 @@ func newCluster(namespacedName *types.NamespacedName) *clusterv1.Cluster {
 	}
 }
 
-func createNode() *v1.Node {
-	return &v1.Node{
+func createNode() *corev1.Node {
+	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "foo",
 			Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
 		},
-		Status: v1.NodeStatus{
-			Addresses: []v1.NodeAddress{
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
 				{
-					Type:    v1.NodeExternalIP,
+					Type:    corev1.NodeExternalIP,
 					Address: "1.1.1.1",
 				},
 			},
@@ -1735,7 +1820,7 @@ func createClusterWithControlPlane(namespace string) (*clusterv1.Cluster, *cpv1b
 
 	cluster := newCluster(&types.NamespacedName{Name: kcpName, Namespace: namespace})
 	cluster.Spec = clusterv1.ClusterSpec{
-		ControlPlaneRef: &v1.ObjectReference{
+		ControlPlaneRef: &corev1.ObjectReference{
 			Kind:       "K0sControlPlane",
 			Namespace:  namespace,
 			Name:       kcpName,
@@ -1764,10 +1849,11 @@ func createClusterWithControlPlane(namespace string) (*clusterv1.Cluster, *cpv1b
 					UID:        "1",
 				},
 			},
+			Finalizers: []string{cpv1beta1.K0sControlPlaneFinalizer},
 		},
-		Spec: v1beta1.K0sControlPlaneSpec{
-			MachineTemplate: &v1beta1.K0sControlPlaneMachineTemplate{
-				InfrastructureRef: v1.ObjectReference{
+		Spec: cpv1beta1.K0sControlPlaneSpec{
+			MachineTemplate: &cpv1beta1.K0sControlPlaneMachineTemplate{
+				InfrastructureRef: corev1.ObjectReference{
 					Kind:       "GenericInfrastructureMachineTemplate",
 					Namespace:  namespace,
 					Name:       "infra-foo",

--- a/internal/controller/util/util.go
+++ b/internal/controller/util/util.go
@@ -1,6 +1,13 @@
 package util
 
-import km "github.com/k0smotron/k0smotron/api/k0smotron.io/v1beta1"
+import (
+	"context"
+
+	km "github.com/k0smotron/k0smotron/api/k0smotron.io/v1beta1"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
 
 func DefaultK0smotronClusterLabels(kmc *km.Cluster) map[string]string {
 	return map[string]string{
@@ -49,4 +56,35 @@ func AddToExistingSans(existing []string, new []string) []string {
 	}
 
 	return finalSans
+}
+
+// EnsureFinalizer adds a finalizer if the object doesn't have a deletionTimestamp set
+// and if the finalizer is not already set.
+// This util is usually used in reconcilers directly after the reconciled object was retrieved
+// and before pause is handled or "defer patch" with the patch helper.
+//
+// TODO: This function is copied from https://github.com/kubernetes-sigs/cluster-api/blob/v1.9.0/util/finalizers/finalizers.go.
+// Use it once the CAPI dependency is bumped to >=v1.9.0.
+func EnsureFinalizer(ctx context.Context, c client.Client, o client.Object, finalizer string) (finalizerAdded bool, err error) {
+	// Finalizers can only be added when the deletionTimestamp is not set.
+	if !o.GetDeletionTimestamp().IsZero() {
+		return false, nil
+	}
+
+	if controllerutil.ContainsFinalizer(o, finalizer) {
+		return false, nil
+	}
+
+	patchHelper, err := patch.NewHelper(o, c)
+	if err != nil {
+		return false, err
+	}
+
+	controllerutil.AddFinalizer(o, finalizer)
+
+	if err := patchHelper.Patch(ctx, o); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }

--- a/inttest/capi-config-update-vm/capi_config_update_vm_test.go
+++ b/inttest/capi-config-update-vm/capi_config_update_vm_test.go
@@ -89,7 +89,7 @@ func (s *CAPIConfigUpdateVMSuite) TestCAPIConfigUpdateVMWorker() {
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("docker-test-cluster"))
 	}()
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
@@ -153,12 +153,6 @@ func (s *CAPIConfigUpdateVMSuite) updateClusterObjects() {
 	// Exec via kubectl
 	out, err := exec.Command("kubectl", "apply", "-f", s.updateClusterYamlsPath).CombinedOutput()
 	s.Require().NoError(err, "failed to apply cluster objects: %s", string(out))
-}
-
-func (s *CAPIConfigUpdateVMSuite) deleteCluster() {
-	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "cluster", "docker-test-cluster").CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func getLBPort(name string) (int, error) {

--- a/inttest/capi-controlplane-docker-downscaling/capi_controlplane_docker_downscaling_test.go
+++ b/inttest/capi-controlplane-docker-downscaling/capi_controlplane_docker_downscaling_test.go
@@ -90,7 +90,7 @@ func (s *CAPIControlPlaneDockerDownScalingSuite) TestCAPIControlPlaneDockerDownS
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("docker-test"))
 	}()
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
@@ -169,12 +169,6 @@ func (s *CAPIControlPlaneDockerDownScalingSuite) updateClusterObjects() {
 	// Exec via kubectl
 	out, err := exec.Command("kubectl", "apply", "-f", s.clusterYamlsUpdatePath).CombinedOutput()
 	s.Require().NoError(err, "failed to update cluster objects: %s", string(out))
-}
-
-func (s *CAPIControlPlaneDockerDownScalingSuite) deleteCluster() {
-	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "-f", s.clusterYamlsPath).CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func getLBPort(name string) (int, error) {

--- a/inttest/capi-controlplane-docker-rm/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker-rm/capi_controlplane_docker_test.go
@@ -87,7 +87,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("docker-test-cluster"))
 	}()
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
@@ -147,12 +147,6 @@ func (s *CAPIControlPlaneDockerSuite) applyClusterObjects() {
 	// Exec via kubectl
 	out, err := exec.Command("kubectl", "apply", "-f", s.clusterYamlsPath).CombinedOutput()
 	s.Require().NoError(err, "failed to apply cluster objects: %s", string(out))
-}
-
-func (s *CAPIControlPlaneDockerSuite) deleteCluster() {
-	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "-f", s.clusterYamlsPath).CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func getDockerNodeFile(nodeName string, path string) (string, error) {

--- a/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
+++ b/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
@@ -89,7 +89,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("docker-test-cluster"))
 	}()
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
@@ -186,12 +186,6 @@ func (s *CAPIControlPlaneDockerSuite) applyClusterObjects() {
 	// Exec via kubectl
 	out, err := exec.Command("kubectl", "apply", "-f", s.clusterYamlsPath).CombinedOutput()
 	s.Require().NoError(err, "failed to apply cluster objects: %s", string(out))
-}
-
-func (s *CAPIControlPlaneDockerSuite) deleteCluster() {
-	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "-f", s.clusterYamlsPath).CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func getLBPort(name string) (int, error) {

--- a/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
+++ b/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
@@ -88,7 +88,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("docker-test-cluster"))
 	}()
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
@@ -171,12 +171,6 @@ func (s *CAPIControlPlaneDockerSuite) applyClusterObjects() {
 	// Exec via kubectl
 	out, err := exec.Command("kubectl", "apply", "-f", s.clusterYamlsPath).CombinedOutput()
 	s.Require().NoError(err, "failed to apply cluster objects: %s", string(out))
-}
-
-func (s *CAPIControlPlaneDockerSuite) deleteCluster() {
-	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "-f", s.clusterYamlsPath).CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func getLBPort(name string) (int, error) {

--- a/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
+++ b/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
@@ -85,7 +85,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDockerWorker() {
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("docker-test-cluster"))
 	}()
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
@@ -131,12 +131,6 @@ func (s *CAPIControlPlaneDockerSuite) applyClusterObjects() {
 	// Exec via kubectl
 	out, err := exec.Command("kubectl", "apply", "-f", s.clusterYamlsPath).CombinedOutput()
 	s.Require().NoError(err, "failed to apply cluster objects: %s", string(out))
-}
-
-func (s *CAPIControlPlaneDockerSuite) deleteCluster() {
-	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "cluster", "docker-test-cluster").CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func getLBPort(name string) (int, error) {

--- a/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
@@ -19,14 +19,15 @@ package capicontolplanedocker
 import (
 	"context"
 	"fmt"
-	controlplanev1beta1 "github.com/k0smotron/k0smotron/api/controlplane/v1beta1"
 	"os"
 	"os/exec"
-	"sigs.k8s.io/cluster-api/api/v1beta1"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	controlplanev1beta1 "github.com/k0smotron/k0smotron/api/controlplane/v1beta1"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/k0smotron/k0smotron/inttest/util"
 
@@ -88,7 +89,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("docker-test-cluster"))
 	}()
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
@@ -178,12 +179,6 @@ func (s *CAPIControlPlaneDockerSuite) applyClusterObjects() {
 	// Exec via kubectl
 	out, err := exec.Command("kubectl", "apply", "-f", s.clusterYamlsPath).CombinedOutput()
 	s.Require().NoError(err, "failed to apply cluster objects: %s", string(out))
-}
-
-func (s *CAPIControlPlaneDockerSuite) deleteCluster() {
-	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "-f", s.clusterYamlsPath).CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func getDockerNodeFile(nodeName string, path string) (string, error) {

--- a/inttest/capi-docker-machine-change-template/capi_docker_machine_change_template_test.go
+++ b/inttest/capi-docker-machine-change-template/capi_docker_machine_change_template_test.go
@@ -19,14 +19,15 @@ package capidockermachinechangetemplate
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"os"
 	"os/exec"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/k0smotron/k0smotron/inttest/util"
 	k0stestutil "github.com/k0sproject/k0s/inttest/common"
@@ -94,7 +95,7 @@ func (s *CAPIDockerMachineChangeTemplate) TestCAPIControlPlaneDockerDownScaling(
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("docker-test"))
 	}()
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
@@ -232,13 +233,6 @@ func (s *CAPIDockerMachineChangeTemplate) updateClusterObjectsAgain() {
 	// Exec via kubectl
 	out, err := exec.Command("kubectl", "apply", "-f", s.clusterYamlsSecondUpdatePath).CombinedOutput()
 	s.Require().NoError(err, "failed to update cluster objects: %s", string(out))
-}
-
-func (s *CAPIDockerMachineChangeTemplate) deleteCluster() {
-	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "cluster", "docker-test").CombinedOutput()
-	//out, err := exec.Command("kubectl", "delete", "-f", s.clusterYamlsPath).CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func getLBPort(name string) (int, error) {

--- a/inttest/capi-docker-machine-template-update-recreate-kine/capi_docker_machine_template_update_recreate_test.go
+++ b/inttest/capi-docker-machine-template-update-recreate-kine/capi_docker_machine_template_update_recreate_test.go
@@ -19,7 +19,6 @@ package capidockermachinetemplateupdaterecreatekine
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"net"
 	"os"
 	"os/exec"
@@ -28,6 +27,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
@@ -98,7 +99,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreateKine) TestCAPIControlPlaneDocker
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("docker-test"))
 	}()
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
@@ -200,12 +201,6 @@ func (s *CAPIDockerMachineTemplateUpdateRecreateKine) updateClusterObjects() {
 	// Exec via kubectl
 	out, err := exec.Command("kubectl", "apply", "-f", s.clusterYamlsUpdatePath).CombinedOutput()
 	s.Require().NoError(err, "failed to update cluster objects: %s", string(out))
-}
-
-func (s *CAPIDockerMachineTemplateUpdateRecreateKine) deleteCluster() {
-	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "-f", s.clusterYamlsPath).CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func getPostgresAddress() (string, error) {

--- a/inttest/capi-docker-machine-template-update-recreate-single/capi_docker_machine_template_update_recreate_single_test.go
+++ b/inttest/capi-docker-machine-template-update-recreate-single/capi_docker_machine_template_update_recreate_single_test.go
@@ -90,7 +90,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreateSingle) TestCAPIControlPlaneDock
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("docker-test"))
 	}()
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
@@ -182,12 +182,6 @@ func (s *CAPIDockerMachineTemplateUpdateRecreateSingle) updateClusterObjects() {
 	// Exec via kubectl
 	out, err := exec.Command("kubectl", "apply", "-f", s.clusterYamlsUpdatePath).CombinedOutput()
 	s.Require().NoError(err, "failed to update cluster objects: %s", string(out))
-}
-
-func (s *CAPIDockerMachineTemplateUpdateRecreateSingle) deleteCluster() {
-	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "-f", s.clusterYamlsPath).CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func getLBPort(name string) (int, error) {

--- a/inttest/capi-docker-machine-template-update-recreate/capi_docker_machine_template_update_recreate_test.go
+++ b/inttest/capi-docker-machine-template-update-recreate/capi_docker_machine_template_update_recreate_test.go
@@ -19,13 +19,14 @@ package capidockermachinetemplateupdaterecreate
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/k0smotron/k0smotron/inttest/util"
 	k0stestutil "github.com/k0sproject/k0s/inttest/common"
@@ -91,7 +92,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreate) TestCAPIControlPlaneDockerDown
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("docker-test"))
 	}()
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
@@ -189,12 +190,6 @@ func (s *CAPIDockerMachineTemplateUpdateRecreate) updateClusterObjects() {
 	// Exec via kubectl
 	out, err := exec.Command("kubectl", "apply", "-f", s.clusterYamlsUpdatePath).CombinedOutput()
 	s.Require().NoError(err, "failed to update cluster objects: %s", string(out))
-}
-
-func (s *CAPIDockerMachineTemplateUpdateRecreate) deleteCluster() {
-	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "cluster", "docker-test").CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func getLBPort(name string) (int, error) {

--- a/inttest/capi-docker-machine-template-update/capi_docker_machine_template_update_test.go
+++ b/inttest/capi-docker-machine-template-update/capi_docker_machine_template_update_test.go
@@ -93,7 +93,7 @@ func (s *CAPIControlPlaneDockerDownScalingSuite) TestCAPIControlPlaneDockerDownS
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("docker-test"))
 	}()
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
@@ -204,12 +204,6 @@ func (s *CAPIControlPlaneDockerDownScalingSuite) updateClusterObjectsAgain() {
 	// Exec via kubectl
 	out, err := exec.Command("kubectl", "apply", "-f", s.clusterYamlsSecondUpdatePath).CombinedOutput()
 	s.Require().NoError(err, "failed to update cluster objects: %s", string(out))
-}
-
-func (s *CAPIControlPlaneDockerDownScalingSuite) deleteCluster() {
-	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "-f", s.clusterYamlsPath).CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func getLBPort(name string) (int, error) {

--- a/inttest/capi-docker-machinedeployment/capi_docker_test.go
+++ b/inttest/capi-docker-machinedeployment/capi_docker_test.go
@@ -78,7 +78,7 @@ func (s *CAPIDockerSuite) TestCAPIDocker() {
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("docker-md-test"))
 	}()
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
@@ -154,10 +154,4 @@ func (s *CAPIDockerSuite) applyClusterObjects() {
 	// Exec via kubectl
 	out, err := exec.Command("kubectl", "apply", "-f", "../../config/samples/capi/docker/cluster-with-machinedeployment.yaml").CombinedOutput()
 	s.Require().NoError(err, "failed to apply cluster objects: %s", string(out))
-}
-
-func (s *CAPIDockerSuite) deleteCluster() {
-	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "cluster", "docker-md-test").CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }

--- a/inttest/capi-remote-machine-template-update/capi_remote_machine_template_update_test.go
+++ b/inttest/capi-remote-machine-template-update/capi_remote_machine_template_update_test.go
@@ -135,7 +135,7 @@ func (s *RemoteMachineTemplateUpdateSuite) TestCAPIRemoteMachine() {
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("remote-test-cluster"))
 	}()
 
 	s.createCluster()
@@ -227,11 +227,6 @@ func (s *RemoteMachineTemplateUpdateSuite) getRemoteMachine(name string, namespa
 		return nil, err
 	}
 	return rm, nil
-}
-
-func (s *RemoteMachineTemplateUpdateSuite) deleteCluster() {
-	out, err := exec.Command("kubectl", "delete", "-f", s.clusterYamlsPath).CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func (s *RemoteMachineTemplateUpdateSuite) updateCluster() {

--- a/inttest/capi-remote-machine-template/capi_remote_machine_template_test.go
+++ b/inttest/capi-remote-machine-template/capi_remote_machine_template_test.go
@@ -133,7 +133,7 @@ func (s *RemoteMachineTemplateSuite) TestCAPIRemoteMachine() {
 			return
 		}
 		s.T().Log("Deleting cluster objects")
-		s.deleteCluster()
+		s.Require().NoError(util.DeleteCluster("remote-test-cluster"))
 	}()
 
 	s.createCluster()
@@ -204,11 +204,6 @@ func (s *RemoteMachineTemplateSuite) deleteRemoteMachine(name string, namespace 
 	apiPath := fmt.Sprintf("/apis/infrastructure.cluster.x-k8s.io/v1beta1/namespaces/%s/remotemachines/%s", namespace, name)
 	_, err := s.client.RESTClient().Delete().AbsPath(apiPath).DoRaw(s.Context())
 	return err
-}
-
-func (s *RemoteMachineTemplateSuite) deleteCluster() {
-	out, err := exec.Command("kubectl", "delete", "-f", s.clusterYamlsPath).CombinedOutput()
-	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 
 func (s *RemoteMachineTemplateSuite) createCluster() {


### PR DESCRIPTION
Machine object needs to find the existing cluster it belongs to in order to complete its removal. This means that the cluster should be removed after all Machines have been deleted.

With the current implementation, we are not enforcing the correct deletion order. Running a common `kubectl delete cluster ...` triggers [background cascade deletion](https://kubernetes.io/docs/concepts/architecture/garbage-collection/#background-deletion) by default, meaning the cluster is removed immediately, and the garbage collector removes dependent resources in the background.

Currently, the cluster controller waits for the K0ControlPlane deletion but not for the control plane machines. If the K0sControlPlane is deleted quickly, the cluster is also removed, preventing the machine controller from finding the cluster to complete machine deletions. This leaves machines in a dangling state, stuck in _Deleting_ but never actually being removed.

With this change, since the cluster controller now waits for K0sControlPlane deletion, the deletion of the control plane resource is properly managed. This ensures that Machines are deleted first, leading to a graceful removal of all resources (K0sControlPlane, Machines, K0sControllerConfig, etc.) related to the cluster.