### PR TITLE
Stabilize SANS field order in ClusterConfig

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/imdario/mergo"
@@ -221,6 +222,9 @@ func (r *ClusterReconciler) genSANs(kmc *km.Cluster) ([]string, error) {
 	// Trim the trailing dot from the CNAME
 	trimmedCNAME, _ := strings.CutSuffix(cname, ".")
 	sans = append(sans, trimmedCNAME)
+
+	// Sort the sans to ensure stable output order
+	sort.Strings(sans)
 
 	return sans, nil
 }

--- a/internal/controller/util/util.go
+++ b/internal/controller/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"sort"
 
 	km "github.com/k0smotron/k0smotron/api/k0smotron.io/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -54,6 +55,9 @@ func AddToExistingSans(existing []string, new []string) []string {
 	for key := range uniques {
 		finalSans = append(finalSans, key)
 	}
+
+	// Sort the sans to ensure stable output order
+	sort.Strings(finalSans)
 
 	return finalSans
 }


### PR DESCRIPTION
## Overview
This PR stabilizes the order of the `api.sans` field in ClusterConfig to ensure consistent output across reconciliations.

fixes #985

## Problem
Currently, the `api.sans` field in ClusterConfig gets generated with an unstable order during each reconciliation. This causes unnecessary diffs to be detected, leading to components like kube-router being unnecessarily restarted, affecting overall system stability.

## Solution
- Sort the SANS list consistently after generation to ensure a stable output order
- Modified two key functions:
  - Updated `AddToExistingSans` to return a sorted slice
  - Updated `genSANs` to ensure the generated SANS are in a consistent order

## Testing
All tests pass with the updated implementation.

This change improves system stability by preventing unnecessary pod restarts caused by non-semantic configuration changes.