### PR TITLE
Fixes a bug in cluster spec comparison

### DIFF
--- a/internal/controller/controlplane/k0smotron_controlplane_controller.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller.go
@@ -460,7 +460,7 @@ func isClusterSpecEqual(spec1, spec2 kapi.ClusterSpec) bool {
 	}
 	spec2.CertificateRefs = spec2Certs
 
-	return reflect.DeepEqual(spec1.CertificateRefs, spec2.CertificateRefs)
+	return reflect.DeepEqual(spec1, spec2)
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
Probably a "typo" that causes regression in the last release. Basically, HCPs are not updated on K0smotronControlPlane updates in v1.5.0