### PR TITLE
Add jinja template cloud init

### DIFF
--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -41,11 +41,11 @@ func (c *CloudInit) AsBytes() ([]byte, error) {
 	var b bytes.Buffer
 
 	// Write the "header" first
-	_, err = b.WriteString("## template: jinja\n")
+	_, err := b.WriteString("## template: jinja\n")
 	if err != nil {
 		return nil, err
 	}
-	_, err := b.WriteString("#cloud-config\n")
+	_, err = b.WriteString("#cloud-config\n")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -41,6 +41,10 @@ func (c *CloudInit) AsBytes() ([]byte, error) {
 	var b bytes.Buffer
 
 	// Write the "header" first
+	_, err = b.WriteString("## template: jinja\n")
+	if err != nil {
+		return nil, err
+	}
 	_, err := b.WriteString("#cloud-config\n")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add the jinja templating header to cloud init file to allow for templating when generating k0s service from cloud init. Useful for injecting metadata from cloud instances into k0s, like provider-id or node public ip. 

The idea comes from a similar idea in Kubeadm node bootstraper for clusterapi